### PR TITLE
feat(autocomplete): Make Flow autocomplete priority configurable

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -2,6 +2,7 @@ const {
     AutoLanguageClient
 } = require('atom-languageclient')
 const cp = require('child_process')
+const PACKAGE_NAME = require('../package.json').name;
 
 class GolangLanguageClient extends AutoLanguageClient {
     getGrammarScopes() {
@@ -33,6 +34,13 @@ class GolangLanguageClient extends AutoLanguageClient {
             // load specific gopls settings from config
             let goplsSettings = atom.config.get("gopls");
             return [goplsSettings];
+        });
+    }
+
+    provideAutocomplete() {
+        const config = atom.config.get(PACKAGE_NAME);
+        return Object.assign(super.provideAutocomplete(), {
+            suggestionPriority: config.goplsAutocompleteResultsFirst ? 5 : 1
         });
     }
 
@@ -96,3 +104,15 @@ class GolangLanguageClient extends AutoLanguageClient {
 }
 
 module.exports = new GolangLanguageClient()
+
+module.exports.config = {
+    goplsAutocompleteResultsFirst: {
+        type: 'boolean',
+        title: 'Show Gopls autocomplete results first',
+        description:
+            'If checked, Gopls suggestions will be placed before the rest of autocomplete results ' +
+            '(e.g. snippets etc.). Requires restart to take effect.',
+        default: true,
+        order: 50,
+    },
+};

--- a/lib/main.js
+++ b/lib/main.js
@@ -38,6 +38,7 @@ class GolangLanguageClient extends AutoLanguageClient {
     }
 
     provideAutocomplete() {
+        // Perfer gopls autocompletion results take priority
         const config = atom.config.get(PACKAGE_NAME);
         return Object.assign(super.provideAutocomplete(), {
             suggestionPriority: config.goplsAutocompleteResultsFirst ? 5 : 1
@@ -108,9 +109,9 @@ module.exports = new GolangLanguageClient()
 module.exports.config = {
     goplsAutocompleteResultsFirst: {
         type: 'boolean',
-        title: 'Show Gopls autocomplete results first',
+        title: 'Show gopls autocomplete results first',
         description:
-            'If checked, Gopls suggestions will be placed before the rest of autocomplete results ' +
+            'If checked, gopls suggestions will be placed before the rest of autocomplete results ' +
             '(e.g. snippets etc.). Requires restart to take effect.',
         default: true,
         order: 50,


### PR DESCRIPTION
Hi, I found some autocomplete priority with snippets,
other project have this issue too, such as
https://github.com/facebookarchive/atom-ide-ui/issues/157
https://github.com/facebookarchive/ide-flowtype/issues/65
https://github.com/atom/autocomplete-plus/issues/946
Finally I search the solution like this https://github.com/facebookarchive/ide-flowtype/pull/60
So I think we need do it also. And made this feature.