### PR TITLE
Fix for autocomplete on imports.

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -69,7 +69,7 @@ class GolangLanguageClient extends AutoLanguageClient {
         // apply additional edits for the suggestion
         let buf = args.editor.getBuffer();
         if (args.suggestion.additionalTextEdits) {
-            args.suggestion.additionalTextEdits.forEach(function(item) {
+            args.suggestion.additionalTextEdits.reverse().forEach(function(item) {
                 buf.insert([item.range.start.line, item.range.start.character], item.newText);
             });
         }


### PR DESCRIPTION
Issue https://github.com/MordFustang21/ide-gopls/issues/6.

The issue is that gopls sends back the coordinates for the text in the 
actual buffer and does not consider the changes made along the replaces. 
So, as soon as the first replace in the text happens all other 
coordinates are automatically wrong.

Replaced text suggestions from bottom to top (reverse for-each), so it 
will prevent text to be moved from it's original place.