### PR TITLE
Fixes for autocomplete

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -70,7 +70,10 @@ class GolangLanguageClient extends AutoLanguageClient {
         let buf = args.editor.getBuffer();
         if (args.suggestion.additionalTextEdits) {
             args.suggestion.additionalTextEdits.reverse().forEach(function(item) {
-                buf.insert([item.range.start.line, item.range.start.character], item.newText);
+                buf.setTextInRange({
+                    start:{row: item.range.start.line, column: item.range.start.character},
+                    end:{row: item.range.end.line, column: item.range.end.character}
+                }, item.newText)
             });
         }
     }


### PR DESCRIPTION
updated how changes are applied, instead of inserting changes it is now replaced as some suggestions from gopls are line removals.

Issue:
response from gopls sometimes brings lines to be removed, and this removal was represented by "" (empty quotes) which in the previous procedure didn't work as expected.

Actually,
```go
...
import (
  "time"
  "fmt"
)
...
```
Is wrongly updated to:
```go
...
import (
  "tifmet"
  "fmos"
  "time"
)
...
```

Expectation:
gopls range should be replaced by gopls suggestions and not inserted, giving the ability to "move" suggested lines

```go
...
import (
  "fmt"   // moved up as gopls suggested
  "os"    // inserted suggestion
  "time"  // moved down
)
...
```

Result:
textBuffer.setTextInRange is implemented instead of textBuffer.insert