### PR TITLE
Running gopls as a daemon

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -89,7 +89,7 @@ class GolangLanguageClient extends AutoLanguageClient {
 
         let env = process.env;
 
-        const childProcess = cp.spawn('gopls', ['-mode=stdio'], {
+        const childProcess = cp.spawn('gopls', ['-mode=stdio', '-remote=auto'], {
             env: env
         });
 


### PR DESCRIPTION
This will allow running `gopls` as a daemon so all gopls sidecars will connect to a shared `gopls` “daemon” process to improve performance when working with multiple projects.
Ref: https://go.googlesource.com/tools/+/refs/heads/master/gopls/doc/daemon.md